### PR TITLE
Clear history of Safari before running tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,17 @@ const getBrowserLauncher = function(browserName) {
     const script = `
     set wasopen to false
     if application "${browserName}" is running then set wasopen to true
+    tell application "${browserName}" to activate
+    tell application "System Events"    
+        click menu item "Clear History…" of menu 1 of menu bar item "History" of menu bar 1 of process "${browserName}"    
+        try        
+            click button "Clear History" of front window of process "${browserName}"        
+        on error
+            try
+                click button "Clear History" of sheet 1 of window 1 of process "${browserName}"            
+            end try
+        end try
+    end tell
     tell application "${browserName}"
       make new document with properties {URL:"${url}"}
     end tell


### PR DESCRIPTION
Sometimes Safari caches something, that prevents it from running the latest state of the tests.

I didn't find a way to clear it just by deleting some files, as all of them are protected and it's not possible to delete them from terminal. 
But as this runner uses AppleScript anyway, we can do this just by selecting corresponding item in the menu